### PR TITLE
Default Variable Overrides for Mixins

### DIFF
--- a/scss/mixins/_components.buttons.scss
+++ b/scss/mixins/_components.buttons.scss
@@ -2,11 +2,29 @@
 @import "utilities.boxing";
 @import "components.typography";
 
+$button-default-color-bg: $color-default !default;
+$button-default-color-fg: $color-white !default;
+$button-default-disabled-color-bg: $color-lighter-grey !default;
 
-@mixin button--color($bg-color: $color-default, $fg-color: $color-white) {
+$button-border-width: $border-width !default;
+$button-border-style: $border-style !default;
+$button-border-color: transparent !default;
+$button-border-radius: $border-radius !default;
+
+$button-focus-border-color: $color-focus !default;
+$button-focus-shadow: $box-shadow-focus !default;
+
+$button--ghost-color: $border-color !default;
+$button--ghost-hover-color: $color-white !default;
+$button--ghost-border-width: $button-border-width !default;
+$button--ghost-border-style: $button-border-style !default;
+
+$button--rounded-border-radius: $border-radius-rounded !default;
+
+@mixin button--color($bg-color: $button-default-color-bg, $fg-color: $button-default-color-fg) {
   background-color: $bg-color;
   color: $fg-color;
-  border: 1px solid transparent;
+  border: $button-border-width $button-border-style $button-border-color;
 
   &:not(:disabled) {
     &:hover {
@@ -14,19 +32,19 @@
     }
 
     &:focus {
-      border: 1px solid $color-blue;
-      box-shadow: inset 0 0 0 2px $color-light-blue;
+      border-color: $button-focus-border-color;
+      box-shadow: $button-focus-shadow;
     }
 
-    &:active, .button--active {
+    &:active, &.button--active {
       background-color: darken($bg-color, $color-tint);
     }
   }
 }
 
-@mixin button--ghost($color: $border-color, $hover-text-color: $color-white) {
+@mixin button--ghost($color: $button--ghost-color, $hover-text-color: $button--ghost-hover-color) {
   background-color: transparent;
-  border: 1px solid $color;
+  border: $button--ghost-border-width $button--ghost-border-style $color;
   color: $color;
 
   &:not(:disabled) {
@@ -36,13 +54,13 @@
     }
 
     &:focus {
-      border: 1px solid $color-blue;
-      box-shadow: inset 0 0 0 2px $color-light-blue;
+      border-color: $button-focus-border-color;
+      box-shadow: $button-focus-shadow;
     }
 
-    &:active, .button--active {
+    &:active, &.button--active {
       background-color: darken($color, $color-tint);
-      border: 1px solid darken($color, $color-tint);
+      border-color: darken($color, $color-tint);
       color: $hover-text-color;
     }
   }
@@ -55,7 +73,7 @@
   margin: 0;
   max-width: 100%;
   border: 0;
-  border-radius: $border-radius;
+  border-radius: $button-border-radius;
   @include text-size--medium;
   text-decoration: none;
   text-transform: uppercase;
@@ -70,14 +88,14 @@
 
   &:disabled {
     @include text--quiet;
-    background-color: $color-lighter-grey;
+    background-color: $button-default-disabled-color-bg;
     font-style: italic;
     cursor: not-allowed;
   }
 }
 
 @mixin button--rounded {
-  border-radius: $border-radius-rounded;
+  border-radius: $button--rounded-border-radius;
 }
 
 @mixin button--close {
@@ -104,11 +122,11 @@
   border-radius: 0;
 
   &:first-child {
-    border-radius: $border-radius 0 0 $border-radius;
+    border-radius: $button-border-radius 0 0 $button-border-radius;
   }
 
   &:last-child {
-    border-radius: 0 $border-radius $border-radius 0;
+    border-radius: 0 $button-border-radius $button-border-radius 0;
   }
 }
 
@@ -116,11 +134,11 @@
   border-radius: 0;
 
   &:first-child {
-    border-radius: $border-radius-rounded 0 0 $border-radius-rounded;
+    border-radius: $button--rounded-border-radius 0 0 $button--rounded-border-radius;
   }
 
   &:last-child {
-    border-radius: 0 $border-radius-rounded $border-radius-rounded 0;
+    border-radius: 0 $button--rounded-border-radius $button--rounded-border-radius 0;
   }
 }
 

--- a/scss/mixins/_components.buttons.scss
+++ b/scss/mixins/_components.buttons.scss
@@ -5,6 +5,8 @@
 $button-default-color-bg: $color-default !default;
 $button-default-color-fg: $color-white !default;
 $button-default-disabled-color-bg: $color-lighter-grey !default;
+$button-default-font-family: inherit !default;
+$button-default-disabled-font-style: italic !default;
 
 $button-border-width: $border-width !default;
 $button-border-style: $border-style !default;
@@ -75,6 +77,7 @@ $button--rounded-border-radius: $border-radius-rounded !default;
   border: 0;
   border-radius: $button-border-radius;
   @include text-size--medium;
+  font-family: $button-default-font-family;
   text-decoration: none;
   text-transform: uppercase;
   overflow: hidden;
@@ -89,7 +92,7 @@ $button--rounded-border-radius: $border-radius-rounded !default;
   &:disabled {
     @include text--quiet;
     background-color: $button-default-disabled-color-bg;
-    font-style: italic;
+    font-style: $button-default-disabled-font-style;
     cursor: not-allowed;
   }
 }

--- a/scss/mixins/_components.calendars.scss
+++ b/scss/mixins/_components.calendars.scss
@@ -4,6 +4,20 @@
 @import "components.typography";
 @import "components.buttons";
 
+$calendar-max-width: 400px !default;
+
+$calendar-color-bg: $color-white !default;
+$calendar-color-fg: $color-black !default;
+
+$calendar-border-width: $border-width !default;
+$calendar-border-style: $border-style !default;
+$calendar-border-color: $border-color !default;
+$calendar-border: $calendar-border-width $calendar-border-style $calendar-border-color !default;
+
+$calendar-border-radius: $border-radius !default;
+
+$calendar-today-border-color: $color-light-grey;
+
 @mixin calendar {
   @include grid;
   @include grid--wrap;
@@ -11,14 +25,14 @@
   @include grid__cell--no-gutter;
   @include window-box--xsmall;
   text-align: center;
-  background-color: $color-white;
-  border: 1px solid $border-color;
-  border-radius: $border-radius;
-  max-width: 400px;
+  background-color: $calendar-color-bg;
+  border: $calendar-border;
+  border-radius: $calendar-border-radius;
+  max-width: $calendar-max-width;
   z-index: $z-over-control;
 }
 
-@mixin calendar__control($bg-color: $color-white, $fg-color: $color-black) {
+@mixin calendar__control($bg-color: $calendar-color-bg, $fg-color: $calendar-color-fg) {
   @include button--color($bg-color, $fg-color);
   @include letter-box--medium;
   @include pillar-box--small;
@@ -28,7 +42,7 @@
   margin: 0;
   outline: 0;
   display: inline;
-  border: 1px solid transparent;
+  border: $calendar-border-width $calendar-border-style transparent;
   border-radius: $border-radius;
   cursor: pointer;
   user-select: none;
@@ -55,15 +69,15 @@
 }
 
 @mixin calendar__date--hover {
-  border: 1px solid $border-color;
+  border: $calendar-border;
 }
 
 @mixin calendar__date--in-month {
-  color: $color-black;
+  color: $calendar-color-fg;
 }
 
 @mixin calendar__date--today {
-  border-color: $color-light-grey;
+  border-color: $calendar-today-border-color;
 }
 
 @mixin calendar__date--selected {

--- a/scss/mixins/_components.cards.scss
+++ b/scss/mixins/_components.cards.scss
@@ -2,11 +2,24 @@
 @import "utilities.boxing";
 @import "components.lists";
 
+$card-border-width: $border-width !default;
+$card-border-style: $border-style !default;
+$card-border-color: $color-light-grey !default;
+$card-border: $card-border-width $card-border-style $card-border-color !default;
+
+$card-box-shadow: $box-shadow !default;
+$card-border-radius: $border-radius !default;
+
+$card-divider-color-bg: $color-dark-grey !default;
+$card-divider-color-fg: $color-white !default;
+
+$card-item-active-bg: $card-border-color !default;
+
 @mixin card {
   @include list--unstyled;
   display: block;
-  box-shadow: $box-shadow;
-  border-radius: $border-radius;
+  box-shadow: $card-box-shadow;
+  border-radius: $card-border-radius;
   overflow: hidden;
 }
 
@@ -31,7 +44,7 @@
 @mixin card__item {
   @include window-box--small;
   &:not(:last-child) {
-    border-bottom: 1px solid $color-light-grey;
+    border-bottom: $card-border;
   }
 }
 
@@ -42,9 +55,9 @@
 }
 
 @mixin card__group-divider {
-  height: 1px;
+  height: $card-border-width;
   overflow: hidden;
-  background-color: $color-light-grey;
+  background-color: $card-border-color;
 }
 
 @mixin card__item--divider {
@@ -56,7 +69,7 @@
 }
 
 @mixin card__item--active {
-  background-color: $color-light-grey;
+  background-color: $card-item-active-bg;
 }
 
 @mixin card--high {

--- a/scss/mixins/_components.inputs.scss
+++ b/scss/mixins/_components.inputs.scss
@@ -2,6 +2,21 @@
 @import "utilities.boxing";
 @import "components.typography";
 
+$input-color-bg: $color-white !default;
+
+$input-border-width: $border-width !default;
+$input-border-style: $border-style !default;
+$input-border-color: $border-color !default;
+$input-border: $input-border-width $input-border-style $input-border-color !default;
+
+$input-border-radius: $border-radius !default;
+
+$input-focus-border-color: $color-focus !default;
+$input-focus-shadow: $box-shadow-focus !default;
+
+$input--disabled-color-bg: $color-lighter-grey !default;
+$input--disabled-border-color: $border-color !default;
+
 @mixin label {
   display: block;
   width: 100%;
@@ -18,15 +33,15 @@
   @include text-size--medium;
   font-weight: $text-font-weight;
   font-family: inherit;
-  background-color: $color-white;
-  border: 1px solid $border-color;
-  border-radius: $border-radius;
+  background-color: $input-color-bg;
+  border: $input-border;
+  border-radius: $input-border-radius;
   resize: vertical;
   appearance: none;
 
   &:focus {
-    border: 1px solid $color-blue;
-    box-shadow: inset 0 0 0 2px $color-light-blue;
+    border-color: $input-focus-border-color;
+    box-shadow: $input-focus-shadow;
   }
 }
 
@@ -46,17 +61,17 @@
 
 @mixin field--disabled {
   @include disabled;
-  background-color: $color-lighter-grey;
-  border: 1px solid $border-color;
+  background-color: $input--disabled-color-bg;
+  border-color: $input--disabled-border-color;
 }
 
 @mixin field--error {
-  border: 1px solid $color-error;
+  border-color: $color-error;
   color: $color-error;
 }
 
 @mixin field--success {
-  border: 1px solid $color-success;
+  border-color: $color-success;
 }
 
 @mixin choice {
@@ -69,8 +84,8 @@
   appearance: none;
 
   &:focus {
-    border: 1px solid $color-blue;
-    box-shadow: inset 0 0 0 2px $color-light-blue;
+    border-color: $input-focus-border-color;
+    box-shadow: $input-focus-shadow;
   }
 }
 
@@ -93,8 +108,8 @@
   height: 2.5em;
 
   &:focus {
-    border: 1px solid $color-blue;
-    box-shadow: inset 0 0 0 2px $color-light-blue;
+    border-color: $input-focus-border-color;
+    box-shadow: $input-focus-shadow;
   }
 }
 
@@ -116,8 +131,8 @@
   font-size: $text-font-size * 2;
 
   &:focus {
-    border: 1px solid $color-blue;
-    box-shadow: inset 0 0 0 2px $color-light-blue;
+    border-color: $input-focus-border-color;
+    box-shadow: $input-focus-shadow;
   }
 }
 

--- a/scss/mixins/_components.tables.scss
+++ b/scss/mixins/_components.tables.scss
@@ -3,6 +3,15 @@
 @import "components.typography";
 @import "components.headings";
 
+$table-border-width: $border-width !default;
+$table-border-style: $border-style !default;
+$table-border-color: $border-color !default;
+
+$table-row-striped-bg: $color-lighter-grey !default;
+
+$table-heading-color-bg: $color-light-grey !default;
+$table-heading-border-color: $color-grey !default;
+
 @mixin table {
   display: flex;
   flex-wrap: wrap;
@@ -31,7 +40,7 @@
 }
 
 @mixin table__row--striped {
-  background-color: $color-lighter-grey;
+  background-color: $table-row-striped-bg;
 }
 
 @mixin table__cell {
@@ -47,8 +56,8 @@
   display: flex;
   flex: 1;
   font-weight: bold;
-  background-color: $color-light-grey;
-  border-bottom: 1px solid $color-grey;
+  background-color: $table-heading-color-bg;
+  border-bottom: $table-border-width $table-border-style $table-heading-border-color;
 }
 
 @mixin table__heading--striped {

--- a/scss/mixins/_components.typography.scss
+++ b/scss/mixins/_components.typography.scss
@@ -1,5 +1,19 @@
 @import "settings.global";
 
+$highlight-color-fg: $color-black !default;
+$highlight-color-bg: $color-yellow !default;
+
+$code-color-fg: $color-black !default;
+$code-color-bg: $color-lighter-grey !default;
+
+$keyboard-color-fg: $color-white !default;
+$keyboard-color-bg: $color-primary !default;
+
+$keyboard-border-width: 2px !default;
+$keyboard-border-style: $border-style !default;
+$keyboard-border-color: $color-darker-primary !default;
+$keyboard-border-radius: $border-radius !default;
+
 @mixin text {
   font-family: $text-font-family;
   font-weight: $text-font-weight;
@@ -14,9 +28,9 @@
   font-family: $text-font-family-mono;
 }
 
-@mixin text--highlight {
-  background-color: $color-yellow;
-  color: $color-black;
+@mixin text--highlight($color-fg: $highlight-color-fg, $color-bg: $highlight-color-bg) {
+  background-color: $color-bg;
+  color: $color-fg;
   padding: $spacing-xsmall $spacing-xsmall $spacing-tiny;
   margin: 0 -$spacing-tiny;
 }
@@ -31,7 +45,7 @@
 
 @mixin text--help {
   cursor: help;
-  border-bottom: 1px dashed $color-dark-grey;
+  border-bottom: $border-width dashed $color-dark-grey;
 }
 
 @mixin text-size--super {
@@ -65,10 +79,9 @@
   font-style: normal;
 }
 
-@mixin code {
-  @include text--highlight;
+@mixin code ($color-fg: $code-color-fg, $color-bg: $code-color-bg) {
+  @include text--highlight($color-fg: $color-fg, $color-bg: $color-bg);
   display: inline;
-  background-color: $color-lighter-grey;
   font-family: $text-font-family-mono;
   font-weight: $text-font-weight;
 }
@@ -82,18 +95,16 @@
 }
 
 @mixin keyboard-keys {
-  @include code;
-  background-color: $color-primary;
-  color: $color-white;
-  border-radius: 4px;
-  border-bottom: 2px solid $color-darker-primary;
+  @include code ($color-fg: $keyboard-color-fg, $color-bg: $keyboard-color-bg);
+  border-radius: $keyboard-border-radius;
+  border-bottom: $keyboard-border-width $keyboard-border-style $keyboard-border-color;
 }
 
 @mixin quotation {
   display: block;
   margin: 0;
   padding: $spacing-medium $spacing-large;
-  border-left: 5px solid $color-grey;
+  border-left: 5px $border-style $color-grey;
   font-family: $text-font-family-serif;
 }
 

--- a/scss/mixins/_settings.global.scss
+++ b/scss/mixins/_settings.global.scss
@@ -1,11 +1,19 @@
 // Screen Sizes
+$screen-xsmall: 20em !default;
+$screen-small: 30em !default;
+$screen-medium: 48em !default;
+$screen-large: 64em !default;
+$screen-xlarge: 78em !default;
+$screen-super: 116em !default;
+
+$screen-adjustment: ($screen-xsmall - ($screen-xsmall * 0.9995)) !default;
 $screen-widths: (
-        xsmall: 20em,
-        small: 30em,
-        medium: 48em,
-        large: 64em,
-        xlarge: 78em,
-        super: 116em
+        xsmall: $screen-xsmall,
+        small: $screen-small,
+        medium: $screen-medium,
+        large: $screen-large,
+        xlarge: $screen-xlarge,
+        super: $screen-super
 );
 
 // Grid widths
@@ -107,6 +115,8 @@ $color-primary: $color-blue !default;
 $color-secondary: $color-orange !default;
 $color-success: $color-green !default;
 $color-error: $color-red !default;
+$color-focus: $color-blue !default;
+$color-focus-shadow: $color-light-blue !default;
 
 $color-dark-primary: darken($color-primary, $color-tint);
 $color-darker-primary: darken($color-dark-primary, $color-tint);
@@ -129,6 +139,8 @@ $color-light-error: lighten($color-error, $color-tint);
 $color-lighter-error: lighten($color-light-error, $color-tint);
 
 // Borders
+$border-width: 1px !default;
+$border-style: solid !default;
 $border-color: $color-dark-grey !default;
 $border-radius: 4px !default;
 $border-radius-rounded: 30em !default;
@@ -143,6 +155,8 @@ $box-shadow-solid: 0 0 1px transparentize($color-black, .3) !default;
 $box-shadow-high-solid: 0 0 1px transparentize($color-black, .3), 0 5px 10px -3px transparentize($color-black, .2) !default;
 $box-shadow-higher-solid: 0 0 1px transparentize($color-black, .3), 0 10px 25px -4px transparentize($color-black, .2) !default;
 $box-shadow-highest-solid: 0 0 1px transparentize($color-black, .3), 0 20px 55px -8px transparentize($color-black, .2) !default;
+
+$box-shadow-focus: inset 0 0 0 2px $color-focus-shadow !default;
 
 // Typography
 $text-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif !default;

--- a/scss/mixins/_tools.mediaqueries.scss
+++ b/scss/mixins/_tools.mediaqueries.scss
@@ -1,7 +1,8 @@
 @import "settings.global";
 
+
 @mixin screen--xsmall-up {
-  @media (min-width: #{map-get($screen-widths, xsmall) - 0.01em}) {
+  @media (min-width: #{map-get($screen-widths, xsmall) - $screen-adjustment}) {
     @content;
   }
 }
@@ -37,7 +38,7 @@
 }
 
 @mixin screen--xsmall-down {
-  @media (max-width: #{map-get($screen-widths, xsmall) - 0.01em}) {
+  @media (max-width: #{map-get($screen-widths, xsmall) - $screen-adjustment}) {
     @content;
   }
 }
@@ -73,25 +74,25 @@
 }
 
 @mixin screen--small {
-  @media (min-width: #{map-get($screen-widths, xsmall)}) and (max-width: #{map-get($screen-widths, small) - 0.01em}) {
+  @media (min-width: #{map-get($screen-widths, xsmall)}) and (max-width: #{map-get($screen-widths, small) - $screen-adjustment}) {
     @content;
   }
 }
 
 @mixin screen--medium {
-  @media (min-width: #{map-get($screen-widths, small)}) and (max-width: #{map-get($screen-widths, medium) - 0.01em}) {
+  @media (min-width: #{map-get($screen-widths, small)}) and (max-width: #{map-get($screen-widths, medium) - $screen-adjustment}) {
     @content;
   }
 }
 
 @mixin screen--large {
-  @media (min-width: #{map-get($screen-widths, large)}) and (max-width: #{map-get($screen-widths, xlarge) - 0.01em}) {
+  @media (min-width: #{map-get($screen-widths, large)}) and (max-width: #{map-get($screen-widths, xlarge) - $screen-adjustment}) {
     @content;
   }
 }
 
 @mixin screen--xlarge {
-  @media (min-width: #{map-get($screen-widths, xlarge)}) and (max-width: #{map-get($screen-widths, super)  - 0.01em}) {
+  @media (min-width: #{map-get($screen-widths, xlarge)}) and (max-width: #{map-get($screen-widths, super)  - $screen-adjustment}) {
     @content;
   }
 }


### PR DESCRIPTION
**✨  Variable-ize mixins**
*Re: Issue #67*

While this conversion is not completely exhaustive, it should put things
in an improved position going forward.

Essentially what this does is expose a great deal more default variables
as "api endpoints".  This should allow users of the blaze framework to
customize and theme the base elements more thoroughly, leading to less
boilerplate code (e.g. setting a default button color override, etc).

I feel strongly that exposing more granular variables will lead to
cleaner end-user codebases (and it'd make it a helluva lot easier for me
to use in my own projects).

If I've changed anything that has been done intentionally (e.g. re-defining border width/style on `:focus`) I'm happy to discuss and adjust, but from what I can tell a lot of the adjustments I've made there should be fine.

*NOTE: The contributing doc asks that PRs be pointed to `dev`, but it doesn't exist.  I'm happy to change things up if that changes.* 😄 

*Also, I've intentionally left the compiled files out of this PR to make the diff easier to comprehend.  If/when we reach an agreement on this direction and we're ready to proceed I can drop in the compiled files as well.  Not really sure what's up with the build failing, though.*