### PR TITLE
add c-nav-content__right

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1682,6 +1682,7 @@
 				<a href="#" class="c-nav__item"><i class="fa fa-home"></i> Home</a>
 				<a href="#" class="c-nav__item c-nav__item--active"><i class="fa fa-star"></i> News</a>
 				<a href="#" class="c-nav__item c-nav__item--right"><i class="fa fa-life-ring"></i> Help</a>
+				<span class="c-nav__content c-nav__content--right">Right info</span>
 			</nav>
 			<div class="o-panel o-panel--nav-top o-panel--nav-bottom">
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eget neque mollis, sodales nulla ut, porta

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "file-exists": "^1.0.0",
     "gulp": "~3.9.1",
     "gulp-cssnano": "~2.1.2",
+    "gulp-header": "^1.8.7",
     "gulp-rename": "~1.2.2",
     "gulp-sass": "~2.3.2",
     "gulp-size": "^2.1.0",

--- a/scss/components.navs.scss
+++ b/scss/components.navs.scss
@@ -17,6 +17,10 @@
   .c-nav__content {
     @include nav--inline__item;
   }
+  
+  .c-nav__content--right {
+    @include nav__content--right;
+  }
 
   .c-nav__item {
     @include nav--inline__item;

--- a/scss/mixins/_components.navs.scss
+++ b/scss/mixins/_components.navs.scss
@@ -52,6 +52,10 @@
   color: inherit;
 }
 
+@mixin nav__content--right {
+  float: right;
+}
+
 @mixin nav--inline__item {
   display: inline-block;
 }


### PR DESCRIPTION
fixes #82

Added a nav__content--right mixin instead of using nav__item--right, not sure which idea was best.
Also added content in the example page.