### PR TITLE
Removed additional gulp build output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,6 @@ gulp.task('build', () => {
     }))
     .pipe(header('/*!v<%= pkg.version %>*/', {pkg}))
     .pipe(gulp.dest('dist'))
-    .pipe(gulp.dest('../blazecss.github.io/css'))
 })
 
 gulp.task('demo', () => gulp.src('dist/**/blaze*.min.css').pipe(gulp.dest('demo')))


### PR DESCRIPTION
When running "gulp build", an additional build was being made outside of current director ../blazecss.github.io/css
I am not sure if this is meant to be in the public gulp file?