### PR TITLE
Make .c-button display: inline-block

### DIFF
--- a/scss/mixins/_components.buttons.scss
+++ b/scss/mixins/_components.buttons.scss
@@ -57,7 +57,7 @@
 
 @mixin button {
   @include button-color;
-  display: inline;
+  display: inline-block;
   max-width: 100%;
   margin: $button-margin;
   padding: $button-padding;


### PR DESCRIPTION
Currently .c-button is display: inline, which causes unexpected behaviour.
Making display: inline-block will fix this issue.
See issue and fix here: https://jsfiddle.net/litvinenko1706/td233ey1/3/

P.S. Bootstrap's buttons have display: inline-block too: http://www.qopy.me/yctQ3xBCSemkc8A0x-2Guw