### PR TITLE
feat(tree): hide sub-trees in an expandable item unless expanded

### DIFF
--- a/scss/components.trees.scss
+++ b/scss/components.trees.scss
@@ -28,6 +28,11 @@
     color: $tree-item-expandable-indicator-color;
     content: "\276F";
   }
+
+  // hide sub-trees by default
+  .c-tree {
+    display: none;
+  }
 }
 
 .c-tree__item--expanded {
@@ -35,5 +40,10 @@
     transform: rotate(90deg);
     color: $tree-item-expanded-indicator-color;
     content: "\276F";
+  }
+
+  // show sub-trees when expanded
+  .c-tree {
+    display: block;
   }
 }


### PR DESCRIPTION
Currently, nested `.c-tree` components are not hidden when the `.c-tree__item--expandable` class is applied. (it only changes the state of the expand/collapse icon)

This means that a dynamic tree structure needs to manage class names as well as DOM nodes, which I don't think is ideal, so I am proposing this change to the behavior:

 - when "expandable", sub-trees will be hidden by default
 - when "expanded", the sub-trees will be visible again

I considered using `:not()` here, as it would be a single declaration, but I'm not sure exactly what browsers are targeted by this toolkit.