### PR TITLE
Use existing variables for c-card padding values

### DIFF
--- a/scss/components.cards.scss
+++ b/scss/components.cards.scss
@@ -19,17 +19,23 @@
 }
 
 .c-card__header {
-  padding: $spacing-small $spacing-small 0;
+  padding: $card-header-padding;
 
   .c-heading {
     padding: 0;
   }
 }
 
-.c-card__item,
-.c-card__body,
+.c-card__item {
+  padding: $card-item-padding;
+}
+
+.c-card__body {
+  padding: $card-body-padding;
+}
+
 .c-card__footer {
-  padding: $spacing-small;
+  padding: $card-footer-padding
 }
 
 .c-card__item + .c-card__footer--block {
@@ -37,7 +43,7 @@
 }
 
 .c-card__footer--block {
-  padding: $spacing-small 0 0;
+  padding: $card-footer-block-padding;
 
   .c-input-group .c-button:first-child {
     border-top-left-radius: 0;

--- a/scss/mixins/_settings.global.scss
+++ b/scss/mixins/_settings.global.scss
@@ -467,7 +467,7 @@ $card-image-padding: $spacing-medium 0 0 !default;
 $card-header-padding: $spacing-medium $spacing-medium 0 !default;
 $card-body-padding: $spacing-medium !default;
 $card-footer-padding: $spacing-medium !default;
-$card-footer-block-padding: 0 !default;
+$card-footer-block-padding: $spacing-small 0 0 !default;
 
 $card-item-padding: $spacing-small !default;
 $card-item-border-width: $border-width !default;


### PR DESCRIPTION
The existing variables in _settings.global are the following:
-$card-header-padding
-$card-item-padding
-$card-body-padding,
-$card-footer-padding
-$card-footer-block-padding

Updated the default value of the $card-footer-block-padding variable
to match what was in components.cards